### PR TITLE
refactor: standardize API endpoints to use api/<app_name>/ pattern

### DIFF
--- a/bike_stores/bike_stores/urls.py
+++ b/bike_stores/bike_stores/urls.py
@@ -22,6 +22,6 @@ urlpatterns = [
     # path('', debug.default_urlconf),  # root page
     path('', include('home.urls'), name='home'),  # root page
     path('admin/', admin.site.urls, name='admin'),
-    path('production/api/', include('production.urls'), name='production'),
-    path('sales/api/', include('sales.urls'), name='sales'),
+    path('api/production/', include('production.urls'), name='production'),
+    path('api/sales/', include('sales.urls'), name='sales'),
 ]


### PR DESCRIPTION
- Updated URL structure so that all API endpoints are now under the /api/<app_name>/ prefix.
- Improves consistency, scalability, and aligns with common RESTful conventions.