### PR TITLE
Configure Django settings to load environment variables from .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+SECRET_KEY=django-insecure-5m*cx48a%4^ipw3*$bi+r^c-a5k#yuaq_0)*_h0)wms1r8ail-
+DEBUG=True
+ALLOWED_HOSTS=127.0.0.1,localhost

--- a/bike_stores/bike_stores/settings.py
+++ b/bike_stores/bike_stores/settings.py
@@ -11,21 +11,19 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from pathlib import Path
-
+import os
+from dotenv import load_dotenv 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-
+load_dotenv(os.path.join(BASE_DIR, '..', '.env'))  
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-5m*cx48a%4^ipw3*$bi+r^c-a5k#yuaq_0)*_h0)wms1r8ail-'
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
-ALLOWED_HOSTS = []
+SECRET_KEY = os.getenv('SECRET_KEY')
+DEBUG = os.getenv('DEBUG', 'False').lower() in ('true', '1', 'yes')
+ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', '').split(',') if os.getenv('ALLOWED_HOSTS') else []
 
 
 # Application definition

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ tzdata==2025.2
 requests==2.32.3
 Jinja2==3.1.5
 httpx==0.28.1
+python-dotenv==1.0.1


### PR DESCRIPTION
- Use python-dotenv to load SECRET_KEY, DEBUG, and ALLOWED_HOSTS from .env
- Add .env.example for environment variable reference
- Improve security and flexibility for different environments